### PR TITLE
Add auto-label-and-approve action

### DIFF
--- a/.github/workflows/dependabot_approve_and_label.yml
+++ b/.github/workflows/dependabot_approve_and_label.yml
@@ -1,0 +1,168 @@
+name: approve_and_label
+on: 
+  pull_request:
+    types: [opened, reopened]
+    
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+    
+jobs:
+  evaluate_dependabot_pr:
+    runs-on: ubuntu-latest
+    name: Parse Dependabot PR title
+    # Don't process PRs from forked repos
+    if:
+      github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      dependency_name: ${{ steps.parse_dependabot_pr_automerge.outputs.dependency_name }}
+      version_from: ${{ steps.parse_dependabot_pr_automerge.outputs.version_from }}
+      version_to: ${{ steps.parse_dependabot_pr_automerge.outputs.version_to }}
+      is_auto_merge_candidate: ${{ steps.parse_dependabot_pr_automerge.outputs.is_interesting_package }}
+      is_auto_release_candidate: ${{ steps.parse_dependabot_pr_autorelease.outputs.is_interesting_package }}
+      semver_increment: ${{ steps.parse_dependabot_pr_automerge.outputs.semver_increment }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
+      - name: Read pr-autoflow configuration
+        id: get_pr_autoflow_config
+        uses: endjin/pr-autoflow/actions/read-configuration@v4
+        with:
+          config_file: .github/config/pr-autoflow.json
+      - name: Dependabot PR - AutoMerge Candidate
+        id: parse_dependabot_pr_automerge
+        uses: endjin/pr-autoflow/actions/dependabot-pr-parser@v4
+        with:
+          pr_title: ${{ github.event.pull_request.title }}
+          package_wildcard_expressions: ${{ steps.get_pr_autoflow_config.outputs.AUTO_MERGE_PACKAGE_WILDCARD_EXPRESSIONS }}
+      - name: Dependabot PR - AutoRelease Candidate
+        id: parse_dependabot_pr_autorelease
+        uses: endjin/pr-autoflow/actions/dependabot-pr-parser@v4
+        with:
+          pr_title: ${{ github.event.pull_request.title }}
+          package_wildcard_expressions: ${{ steps.get_pr_autoflow_config.outputs.AUTO_RELEASE_PACKAGE_WILDCARD_EXPRESSIONS }}
+      - name: debug
+        run: |
+          echo "dependency_name : ${{ steps.parse_dependabot_pr_automerge.outputs.dependency_name }}"
+          echo "is_interesting_package (merge) : ${{ steps.parse_dependabot_pr_automerge.outputs.is_interesting_package }}"
+          echo "is_interesting_package (release) : ${{ steps.parse_dependabot_pr_autorelease.outputs.is_interesting_package }}"
+          echo "semver_increment : ${{ steps.parse_dependabot_pr_automerge.outputs.semver_increment }}"
+  
+  approve:
+    runs-on: ubuntu-latest
+    needs: evaluate_dependabot_pr
+    name: Approve auto-mergeable dependabot PRs
+    if: |
+      (github.actor == 'dependabot[bot]' || github.actor == 'dependjinbot[bot]' || github.actor == 'nektos/act') &&
+      needs.evaluate_dependabot_pr.outputs.is_auto_merge_candidate == 'True'
+    steps:
+      - name: Show PR Details
+        run: |
+          echo "<------------------------------------------------>"
+          echo "dependency_name  : ${{needs.evaluate_dependabot_pr.outputs.dependency_name}}"
+          echo "semver_increment : ${{needs.evaluate_dependabot_pr.outputs.semver_increment}}"
+          echo "auto_merge       : ${{needs.evaluate_dependabot_pr.outputs.is_auto_merge_candidate}}"
+          echo "auto_release     : ${{needs.evaluate_dependabot_pr.outputs.is_auto_release_candidate}}"
+          echo "from_version     : ${{needs.evaluate_dependabot_pr.outputs.version_from}}"
+          echo "to_version       : ${{needs.evaluate_dependabot_pr.outputs.version_to}}"
+          echo "<------------------------------------------------>"
+        shell: bash
+      - name: Approve pull request
+        if: |
+          needs.evaluate_dependabot_pr.outputs.is_auto_merge_candidate == 'True' &&
+          (needs.evaluate_dependabot_pr.outputs.semver_increment == 'minor' || needs.evaluate_dependabot_pr.outputs.semver_increment == 'patch')
+        run: |
+          gh pr review "${{ github.event.pull_request.html_url }}" --approve -b "Thank you dependabot 🎊"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Update PR body'
+        if: |
+          needs.evaluate_dependabot_pr.outputs.is_auto_merge_candidate == 'True' &&
+          (needs.evaluate_dependabot_pr.outputs.semver_increment == 'minor' || needs.evaluate_dependabot_pr.outputs.semver_increment == 'patch')
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea   # v7.0.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          retries: 6  # final retry should wait 64 seconds
+          retry-exempt-status-codes: 400,401,404,422    # GH will raise rate limits with 403 & 429 status codes
+          script: |
+            await github.rest.pulls.update({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              pull_number: context.payload.pull_request.number,
+              body: "Bumps '${{needs.evaluate_dependabot_pr.outputs.dependency_name}}' from ${{needs.evaluate_dependabot_pr.outputs.version_from}} to ${{needs.evaluate_dependabot_pr.outputs.version_to}}"
+            })
+
+  check_for_norelease_label:
+    runs-on: ubuntu-latest
+    outputs:
+      no_release: ${{ steps.check_for_norelease_label.outputs.result }}
+    steps:
+    - name: Check for 'no_release' label on PR
+      id: check_for_norelease_label
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea   # v7.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        retries: 6  # final retry should wait 64 seconds
+        retry-exempt-status-codes: 400,401,404,422    # GH will raise rate limits with 403 & 429 status codes
+        script: |
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              issue_number: context.payload.number
+            });
+            core.info("labels: " + JSON.stringify(labels.data))
+            if ( labels.data.map(l => l.name).includes("no_release") ) {
+              core.info("Label found")
+              return true
+            }
+            return false
+    - name: Display 'no_release' status
+      run: |
+        echo "no_release: ${{ steps.check_for_norelease_label.outputs.result }}"
+
+  label_auto_merge:
+    runs-on: ubuntu-latest
+    needs: 
+    - evaluate_dependabot_pr
+    - check_for_norelease_label
+    name: 'Automerge & Label'
+    steps:
+      # Get a token for a different identity so any auto-merge that happens in the next step is
+      # able to trigger other workflows (i.e. our 'auto_release' workflow)
+      # NOTE: This requires the app details to be defined as 'Dependabot' secrets, rather than
+      #       the usual 'Action' secrets as this workflow is triggered by Dependabot.
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@32691ba7c9e7063bd457bd8f2a5703138591fa58   # v1.9
+        with:
+          app_id: ${{ secrets.DEPENDJINBOT_APP_ID }}
+          private_key: ${{ secrets.DEPENDJINBOT_PRIVATE_KEY }}
+      # Run the auto-merge in the GitHub App context, so the event can trigger other workflows
+      - name: 'Set dependabot PR to auto-merge'
+        if: |
+          (github.actor == 'dependabot[bot]' || github.actor == 'dependjinbot[bot]' || github.actor == 'nektos/act') &&
+          needs.evaluate_dependabot_pr.outputs.is_auto_merge_candidate == 'True' &&
+          (needs.evaluate_dependabot_pr.outputs.semver_increment == 'minor' || needs.evaluate_dependabot_pr.outputs.semver_increment == 'patch')
+        run: |
+            gh pr merge ${{ github.event.pull_request.number }} -R ${{ github.repository }} --auto --squash
+        env:
+          GITHUB_TOKEN: '${{ steps.generate_token.outputs.token }}'
+      - name: 'Label non-dependabot PRs and auto-releasable dependabot PRs with "pending_release"'
+        if: |
+          needs.check_for_norelease_label.outputs.no_release == 'false' &&
+          (
+            (github.actor != 'dependabot[bot]' && github.actor != 'dependjinbot[bot]') ||
+            needs.evaluate_dependabot_pr.outputs.is_auto_release_candidate == 'True'
+          )
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea   # v7.0.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          retries: 6  # final retry should wait 64 seconds
+          retry-exempt-status-codes: 400,401,404,422    # GH will raise rate limits with 403 & 429 status codes
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              issue_number: context.payload.pull_request.number,
+              labels: ['pending_release']
+            })


### PR DESCRIPTION
It turns out that the auto-label for release is inextricably intertwined with the dependabot auto merge handling