### PR TITLE
Ensure that the buffer is cleared when disposed

### DIFF
--- a/Solutions/Corvus.HighPerformance/Corvus.HighPerformance/ValueStringBuilder.cs
+++ b/Solutions/Corvus.HighPerformance/Corvus.HighPerformance/ValueStringBuilder.cs
@@ -89,7 +89,7 @@ public ref partial struct ValueStringBuilder
     /// Returns the buffer retrieved from <see cref="RentedChars"/>.
     /// </summary>
     /// <param name="buffer">The buffer to return.</param>
-    /// <para name="clearBuffer">If <see langword="true"/> then clear the buffer when returned.
+    /// <param name="clearBuffer">If <see langword="true"/> then clear the buffer when returned.</param>
     public static void ReturnRentedBuffer(char[]? buffer, bool clearBuffer)
     {
         if (buffer is char[] b)


### PR DESCRIPTION
Add an overload to ReturnRentedBuffer() which allows you to clear the buffer.